### PR TITLE
game: cosmetics

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,9 +25,9 @@ void main() {
   runApp(const MyApp());
 }
 
-void startServices(){
+void startServices() {
   // mqtt doesn't work in web profile
-  if (! kIsWeb) {
+  if (!kIsWeb) {
     mqttService.start();
   }
 }
@@ -55,10 +55,6 @@ class AppConfig {
   double height = -1;
   double width = -1;
   double zoom = 1.0;
-  double button_pic_h = 30.0;
-  double button_pic_w = 30.0;
-  double scanner_pic_h = 194;
-  double scanner_pic_w = 259;
 
   void read(BuildContext context) {
     Size sizeScreen = MediaQuery.of(context).size;
@@ -70,8 +66,9 @@ class AppConfig {
 
     List<String> items = [
       "/apps/pacman/config.json",
-      "/usr/share/pacman/config.json", 
-      "config.json"];
+      "/usr/share/pacman/config.json",
+      "config.json"
+    ];
     for (var item in items) {
       try {
         final File file = File(item);
@@ -81,10 +78,6 @@ class AppConfig {
         height = config["height"] ?? sizeScreen.height;
         width = config["width"] ?? sizeScreen.width;
         zoom = config["zoom"] ?? width / heightMap;
-        button_pic_h = config["button_pic_h"] ?? button_pic_h;
-        button_pic_w = config["button_pic_w"] ?? button_pic_w;
-        scanner_pic_h = config["scanner_pic_h"] ?? scanner_pic_h;
-        scanner_pic_w = config["scanner_pic_w"] ?? scanner_pic_w;
         return;
       } catch (e) {
         continue;
@@ -102,6 +95,42 @@ class Game extends StatelessWidget {
     AppConfig config = AppConfig();
     config.read(context);
     double zoom = config.zoom;
+    PacMan player = PacMan(position: PacMan.initialPosition);
+    WorldMapByTiled map = WorldMapByTiled(
+      'map.tmj',
+      objectsBuilder: {
+        'sensor_left': (properties) => SensorGate(
+              position: properties.position,
+              direction: DiractionGate.left,
+            ),
+        'sensor_right': (properties) => SensorGate(
+              position: properties.position,
+              direction: DiractionGate.right,
+            ),
+        'dot': (properties) => Dot(
+              position: properties.position,
+            ),
+        'dot_power': (properties) => DotPower(
+              position: properties.position,
+            ),
+        'ghost_red': (properties) => Ghost(
+              position: properties.position,
+              type: GhostType.red,
+            ),
+        'ghost_pink': (properties) => Ghost(
+              position: properties.position,
+              type: GhostType.pink,
+            ),
+        'ghost_orange': (properties) => Ghost(
+              position: properties.position,
+              type: GhostType.orange,
+            ),
+        'ghost_blue': (properties) => Ghost(
+              position: properties.position,
+              type: GhostType.blue,
+            ),
+      },
+    );
     return Container(
       color: Colors.white,
       child: Center(
@@ -110,41 +139,7 @@ class Game extends StatelessWidget {
           height: config.height,
           child: BonfireWidget(
             backgroundColor: Colors.white,
-            map: WorldMapByTiled(
-              'map.tmj',
-              objectsBuilder: {
-                'sensor_left': (properties) => SensorGate(
-                      position: properties.position,
-                      direction: DiractionGate.left,
-                    ),
-                'sensor_right': (properties) => SensorGate(
-                      position: properties.position,
-                      direction: DiractionGate.right,
-                    ),
-                'dot': (properties) => Dot(
-                      position: properties.position,
-                    ),
-                'dot_power': (properties) => DotPower(
-                      position: properties.position,
-                    ),
-                'ghost_red': (properties) => Ghost(
-                      position: properties.position,
-                      type: GhostType.red,
-                    ),
-                'ghost_pink': (properties) => Ghost(
-                      position: properties.position,
-                      type: GhostType.pink,
-                    ),
-                'ghost_orange': (properties) => Ghost(
-                      position: properties.position,
-                      type: GhostType.orange,
-                    ),
-                'ghost_blue': (properties) => Ghost(
-                      position: properties.position,
-                      type: GhostType.blue,
-                    ),
-              },
-            ),
+            map: map,
             joystick: Joystick(
               keyboardConfig: KeyboardConfig(),
             ),
@@ -153,11 +148,11 @@ class Game extends StatelessWidget {
             },
             initialActiveOverlays: const ['score'],
             cameraConfig: CameraConfig(
+              smoothCameraEnabled: true,
               zoom: zoom,
+              target: map,
             ),
-            player: PacMan(
-              position: PacMan.initialPosition,
-            ),
+            player: player,
           ),
         ),
       ),

--- a/lib/menu.dart
+++ b/lib/menu.dart
@@ -30,7 +30,7 @@ class _MenuPageState extends State<MenuPage> with TickerProviderStateMixin {
       duration: const Duration(seconds: 5),
     );
     animation = Tween<Offset>(
-      begin: const Offset(-0.1, 0),
+      begin: const Offset(-1, 0),
       end: const Offset(1, 0),
     ).animate(_controller);
     _controller.addStatusListener(_statusListener);
@@ -48,7 +48,13 @@ class _MenuPageState extends State<MenuPage> with TickerProviderStateMixin {
   Widget build(BuildContext context) {
     AppConfig config = AppConfig();
     config.read(context);
-    TextStyle textStyle = const TextStyle(color: Colors.black, fontSize: 20);
+    TextStyle textStyle = TextStyle(
+        color: Colors.black,
+        fontSize: MediaQuery.of(context).size.height * 0.02);
+
+    firstAnim = Transform.scale(scale: ((MediaQuery.of(context).size.height / 48.0) * 0.2), child: firstAnim);
+    secondAnim = Transform.scale(scale: ((MediaQuery.of(context).size.height / 48.0) * 0.2), child: secondAnim);
+
     return Shortcuts(
       shortcuts: {
         LogicalKeySet(LogicalKeyboardKey.enter): EnterButtonIntent(),
@@ -62,81 +68,90 @@ class _MenuPageState extends State<MenuPage> with TickerProviderStateMixin {
         },
         child: Focus(
             autofocus: true,
-            child: Scaffold(
-              backgroundColor: Colors.white,
-              body: Stack(
-                children: [
-                  Center(
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(
-                          'AVNETman',
-                          style: textStyle.copyWith(
-                            fontWeight: FontWeight.bold,
-                            fontSize: 40,
-                          ),
+            child: Center(
+                heightFactor: 0.7,
+                widthFactor: 0.7,
+                child: Scaffold(
+                  backgroundColor: Colors.white,
+                  body: Stack(
+                    children: [
+                      Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              'AVNETman',
+                              style: textStyle.copyWith(
+                                fontWeight: FontWeight.bold,
+                                fontSize:
+                                    MediaQuery.of(context).size.height * 0.1,
+                              ),
+                            ),
+                            SizedBox(
+                                height:
+                                    MediaQuery.of(context).size.height * 0.15),
+                            SlideTransition(
+                              position: animation,
+                              child: Align(
+                                alignment: Alignment.centerLeft,
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    firstAnim,
+                                    SizedBox(width: MediaQuery.of(context).size.width * 0.2),
+                                    secondAnim,
+                                  ],
+                                ),
+                              ),
+                            ),
+                            SizedBox(
+                                height:
+                                    MediaQuery.of(context).size.height * 0.15),
+                            ElevatedButton.icon(
+                              onPressed: () =>
+                                  Navigator.of(context).pushNamed('/game'),
+                              style: ButtonStyle(
+                                padding: MaterialStateProperty.all(
+                                    const EdgeInsets.all(50)),
+                                overlayColor: MaterialStateProperty.all(
+                                  Colors.white.withOpacity(0.2),
+                                ),
+                                side: MaterialStateProperty.all(
+                                  const BorderSide(color: Colors.white),
+                                ),
+                                backgroundColor: MaterialStateProperty.all(
+                                    Colors.transparent),
+                                shadowColor: MaterialStateProperty.all(
+                                    Colors.transparent),
+                              ),
+                              icon: Image.asset('assets/images/button_blue.png',
+                                  fit: BoxFit.fill,
+                                  width:
+                                      MediaQuery.of(context).size.height * 0.1),
+                              label: Text('Start Game',
+                                  style: textStyle.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                    fontSize:
+                                        MediaQuery.of(context).size.height *
+                                            0.05,
+                                  )),
+                            ),
+                          ],
                         ),
-                        const SizedBox(height: 40),
-                        SlideTransition(
-                          position: animation,
-                          child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                firstAnim,
-                                const SizedBox(width: 20),
-                                secondAnim,
-                              ],
-                            ),
-                          ),
-                        ),
-                        const SizedBox(height: 40),
-                        ElevatedButton.icon(
-                          onPressed: () =>
-                              Navigator.of(context).pushNamed('/game'),
-                          style: ButtonStyle(
-                            padding: MaterialStateProperty.all(
-                                const EdgeInsets.all(20)),
-                            overlayColor: MaterialStateProperty.all(
-                              Colors.white.withOpacity(0.2),
-                            ),
-                            side: MaterialStateProperty.all(
-                              const BorderSide(color: Colors.white),
-                            ),
-                            backgroundColor:
-                                MaterialStateProperty.all(Colors.transparent),
-                            shadowColor:
-                                MaterialStateProperty.all(Colors.transparent),
-                          ),
-                          icon: Image.asset('assets/images/button_blue.png',
-                              height: config.button_pic_h,
-                              width: config.button_pic_w,
-                              fit: BoxFit.fill),
-                          label: Text(
-                            'Start Game',
+                      ),
+                      Align(
+                        alignment: Alignment.bottomCenter,
+                        child: Padding(
+                          padding: const EdgeInsets.all(20.0),
+                          child: Text(
+                            'Powered by Bonfire - Flutter',
                             style: textStyle,
                           ),
                         ),
-                      ],
-                    ),
+                      )
+                    ],
                   ),
-                  Align(
-                    alignment: Alignment.bottomCenter,
-                    child: Padding(
-                      padding: const EdgeInsets.all(20.0),
-                      child: Text(
-                        'Powered by Bonfire - Flutter',
-                        style: textStyle.copyWith(
-                          fontSize: 12,
-                        ),
-                      ),
-                    ),
-                  )
-                ],
-              ),
-            )),
+                ))),
       ),
     );
   }

--- a/lib/player/pacman.dart
+++ b/lib/player/pacman.dart
@@ -26,10 +26,10 @@ class PacMan extends SimplePlayer
   late GameState _gameState;
   async.Timer? _debounceSound;
 
-  final textBubble = const Text('Ready for business!',
+final textBubble = const Text('Ready for business!',
       style: TextStyle(
           inherit: false,
-          fontSize: 20.0,
+          fontSize: 60.0,
           color: Colors.green,
           shadows: [
             Shadow(
@@ -93,8 +93,7 @@ class PacMan extends SimplePlayer
   void onMount() {
     _gameState = BonfireInjector.instance.get();
     _gameState.listenChangePower(_pacManChangePower);
-    gameRef.camera.target = null;
-    gameRef.camera.moveLeft(Game.tileSize);
+    gameRef.camera.moveToTargetAnimated(gameRef.camera.target!, zoom: gameRef.camera.zoom - 0.2);
     super.onMount();
   }
 
@@ -126,6 +125,7 @@ class PacMan extends SimplePlayer
 
   @override
   void die() {
+    if (youAreWinner) return;
     Sounds.stopBackgroundSound();
     Sounds.death();
     FollowerWidget.remove('textBubble');
@@ -136,6 +136,7 @@ class PacMan extends SimplePlayer
       onFinish: () {
         if (_gameState.lifes == 0) {
           async.Future.delayed(Duration.zero, () {
+            gameRef.camera.moveToTargetAnimated(gameRef.camera.target!, zoom: 0.00001);
             GameOverDialog.show(context);
             removeFromParent();
           });
@@ -152,9 +153,11 @@ class PacMan extends SimplePlayer
 
   void _checkIfWinner(double dt) {
     if (checkInterval('winner', 1000, dt) && !youAreWinner) {
-      bool winner = gameRef.componentsByType<Dot>().isEmpty;
+      bool winner =  gameRef.componentsByType<Dot>().isEmpty;
       if (winner) {
+        gameRef.camera.moveToTargetAnimated(gameRef.camera.target!, zoom: 0.00001);
         youAreWinner = true;
+        FollowerWidget.remove('textBubble');
         CongratulationsDialog.show(context);
       }
     }

--- a/lib/widgets/congratulation_dialog.dart
+++ b/lib/widgets/congratulation_dialog.dart
@@ -58,6 +58,8 @@ class CongratulationsDialog extends StatelessWidget {
         child: Focus(
             autofocus: true,
             child: Center(
+              heightFactor: 0.7,
+              widthFactor: 0.7,
               child: Material(
                 type: MaterialType.transparency,
                 child: Container(
@@ -91,7 +93,8 @@ class CongratulationsDialog extends StatelessWidget {
                       ),
                       const SizedBox(height: 20),
                       Image.asset("assets/images/scanner_info.png",
-                       width: config.scanner_pic_w, height: config.scanner_pic_h, fit: BoxFit.fill),
+                          height: MediaQuery.of(context).size.height * 0.3,
+                          fit: BoxFit.fill),
                       const SizedBox(height: 20),
                       Text(
                         '...and we will sign you up automatically!',
@@ -99,72 +102,79 @@ class CongratulationsDialog extends StatelessWidget {
                             fontSize: 22, color: Colors.black),
                       ),
                       const SizedBox(height: 20),
-                      ElevatedButton.icon(
-                        style: ButtonStyle(
-                          padding: MaterialStateProperty.all(
-                              const EdgeInsets.all(20)),
-                          overlayColor: MaterialStateProperty.all(
-                            Colors.black.withOpacity(0.4),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          SizedBox(width: MediaQuery.of(context).size.width * 0.01),
+                          ElevatedButton.icon(
+                            style: ButtonStyle(
+                              padding: MaterialStateProperty.all(
+                                  const EdgeInsets.all(20)),
+                              overlayColor: MaterialStateProperty.all(
+                                Colors.black.withOpacity(0.4),
+                              ),
+                              side: MaterialStateProperty.all(
+                                const BorderSide(color: Colors.transparent),
+                              ),
+                              backgroundColor:
+                                  MaterialStateProperty.all(Colors.transparent),
+                              shadowColor:
+                                  MaterialStateProperty.all(Colors.transparent),
+                            ),
+                            onPressed: () {
+                              gameState.reset();
+                              // TODO mqtt message
+                              Navigator.of(context).pushNamedAndRemoveUntil(
+                                '/',
+                                (route) => false,
+                              );
+                            },
+                            icon: Image.asset('assets/images/button_blue.png',
+                                height: MediaQuery.of(context).size.height * 0.1,
+                                fit: BoxFit.fill),
+                            label: Text(
+                              'Yes!',
+                              style: textStyle.copyWith(
+                                  color: Colors.black,
+                                  fontWeight: FontWeight.bold,
+                                  fontSize:
+                                      MediaQuery.of(context).size.height * 0.05),
+                            ),
                           ),
-                          side: MaterialStateProperty.all(
-                            const BorderSide(color: Colors.black),
+                          const SizedBox(width: 50),
+                          ElevatedButton.icon(
+                            style: ButtonStyle(
+                              padding: MaterialStateProperty.all(
+                                  const EdgeInsets.all(20)),
+                              overlayColor: MaterialStateProperty.all(
+                                Colors.black.withOpacity(0.2),
+                              ),
+                              side: MaterialStateProperty.all(
+                                const BorderSide(color: Colors.transparent),
+                              ),
+                              backgroundColor:
+                                  MaterialStateProperty.all(Colors.transparent),
+                              shadowColor:
+                                  MaterialStateProperty.all(Colors.transparent),
+                            ),
+                            onPressed: () {
+                              gameState.reset();
+                              Navigator.of(context).pushNamedAndRemoveUntil(
+                                '/',
+                                (route) => false,
+                              );
+                            },
+                            icon: Image.asset('assets/images/button_red.png',
+                                height: MediaQuery.of(context).size.height * 0.1,
+                                fit: BoxFit.fill),
+                            label: Text('Maybe later!',
+                                style: textStyle.copyWith(
+                                    color: Colors.red,
+                                    fontSize:
+                                        MediaQuery.of(context).size.height * 0.05)),
                           ),
-                          backgroundColor:
-                              MaterialStateProperty.all(Colors.transparent),
-                          shadowColor:
-                              MaterialStateProperty.all(Colors.transparent),
-                        ),
-                        onPressed: () {
-                          gameState.reset();
-                          // TODO mqtt message
-                          Navigator.of(context).pushNamedAndRemoveUntil(
-                            '/',
-                            (route) => false,
-                          );
-                        },
-                        icon: Image.asset('assets/images/button_blue.png',
-                            height: config.button_pic_h,
-                            width: config.button_pic_w,
-                            fit: BoxFit.fill),
-                        label: Text(
-                          'Yes!',
-                          style: textStyle.copyWith(
-                              color: Colors.black, fontWeight: FontWeight.bold),
-                        ),
-                      ),
-                      const SizedBox(height: 10),
-                      ElevatedButton.icon(
-                        style: ButtonStyle(
-                          padding: MaterialStateProperty.all(
-                              const EdgeInsets.all(20)),
-                          overlayColor: MaterialStateProperty.all(
-                            Colors.black.withOpacity(0.2),
-                          ),
-                          side: MaterialStateProperty.all(
-                            const BorderSide(color: Colors.black),
-                          ),
-                          backgroundColor:
-                              MaterialStateProperty.all(Colors.transparent),
-                          shadowColor:
-                              MaterialStateProperty.all(Colors.transparent),
-                        ),
-                        onPressed: () {
-                          gameState.reset();
-                          Navigator.of(context).pushNamedAndRemoveUntil(
-                            '/',
-                            (route) => false,
-                          );
-                        },
-                        icon: Image.asset('assets/images/button_red.png',
-                            height: config.button_pic_h,
-                            width: config.button_pic_w,
-                            fit: BoxFit.fill),
-                        label: Text(
-                          'Maybe later!',
-                          style: textStyle.copyWith(
-                            color: Colors.black,
-                          ),
-                        ),
+                        ],
                       )
                     ],
                   ),

--- a/lib/widgets/game_over_dialog.dart
+++ b/lib/widgets/game_over_dialog.dart
@@ -57,6 +57,8 @@ class GameOverDialog extends StatelessWidget {
         child: Focus(
           autofocus: true,
           child: Center(
+            heightFactor: 0.7,
+            widthFactor: 0.7,
             child: Material(
               type: MaterialType.transparency,
               child: Container(
@@ -72,7 +74,7 @@ class GameOverDialog extends StatelessWidget {
                     Text(
                       'Game Over - Better luck next time',
                       style: textStyle.copyWith(
-                        fontSize: 32,
+                        fontSize: 40,
                         color: Colors.red,
                       ),
                     ),
@@ -80,92 +82,103 @@ class GameOverDialog extends StatelessWidget {
                     Text(
                       'But, would you like to win amazing prizes in our lottery?',
                       style:
-                          textStyle.copyWith(fontSize: 24, color: Colors.white),
+                          textStyle.copyWith(fontSize: 30, color: Colors.white),
                     ),
                     const SizedBox(height: 20),
                     Text(
                       'Just put your business card under our scanner',
                       style:
-                          textStyle.copyWith(fontSize: 22, color: Colors.white),
+                          textStyle.copyWith(fontSize: 26, color: Colors.white),
                     ),
                     const SizedBox(height: 20),
                     Image.asset("assets/images/scanner_info.png",
-                        width: config.scanner_pic_w,
-                        height: config.scanner_pic_h,
+                        height: MediaQuery.of(context).size.height * 0.3,
                         fit: BoxFit.fill),
                     const SizedBox(height: 20),
                     Text(
                       '...and we will sign you up automatically!',
                       style:
-                          textStyle.copyWith(fontSize: 22, color: Colors.white),
+                          textStyle.copyWith(fontSize: 30, color: Colors.white),
                     ),
                     const SizedBox(height: 20),
-                    ElevatedButton.icon(
-                      style: ButtonStyle(
-                        padding:
-                            MaterialStateProperty.all(const EdgeInsets.all(20)),
-                        overlayColor: MaterialStateProperty.all(
-                          Colors.white.withOpacity(0.2),
-                        ),
-                        side: MaterialStateProperty.all(
-                          const BorderSide(color: Colors.white),
-                        ),
-                        backgroundColor:
-                            MaterialStateProperty.all(Colors.transparent),
-                        shadowColor:
-                            MaterialStateProperty.all(Colors.transparent),
+                    Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          SizedBox(width: MediaQuery.of(context).size.width * 0.01),
+                          ElevatedButton.icon(
+                            style: ButtonStyle(
+                              padding: MaterialStateProperty.all(
+                                  const EdgeInsets.all(20)),
+                              overlayColor: MaterialStateProperty.all(
+                                Colors.black.withOpacity(0.4),
+                              ),
+                              side: MaterialStateProperty.all(
+                                const BorderSide(color: Colors.transparent),
+                              ),
+                              backgroundColor: MaterialStateProperty.all(
+                                  Colors.transparent),
+                              shadowColor: MaterialStateProperty.all(
+                                  Colors.transparent),
+                            ),
+                            onPressed: () {
+                              gameState.reset();
+                              // TODO mqtt message
+                              Navigator.of(context).pushNamedAndRemoveUntil(
+                                '/',
+                                (route) => false,
+                              );
+                            },
+                            icon: Image.asset('assets/images/button_blue.png',
+                                height:
+                                    MediaQuery.of(context).size.height * 0.07,
+                                fit: BoxFit.fill),
+                            label: Text(
+                              'Yes!',
+                              style: textStyle.copyWith(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.bold,
+                                  fontSize:
+                                      MediaQuery.of(context).size.height *
+                                          0.05),
+                            ),
+                          ),
+                          const SizedBox(width: 50),
+                          ElevatedButton.icon(
+                            style: ButtonStyle(
+                              padding: MaterialStateProperty.all(
+                                  const EdgeInsets.all(20)),
+                              overlayColor: MaterialStateProperty.all(
+                                Colors.black.withOpacity(0.2),
+                              ),
+                              side: MaterialStateProperty.all(
+                                const BorderSide(color: Colors.transparent),
+                              ),
+                              backgroundColor: MaterialStateProperty.all(
+                                  Colors.transparent),
+                              shadowColor: MaterialStateProperty.all(
+                                  Colors.transparent),
+                            ),
+                            onPressed: () {
+                              gameState.reset();
+                              Navigator.of(context).pushNamedAndRemoveUntil(
+                                '/',
+                                (route) => false,
+                              );
+                            },
+                            icon: Image.asset('assets/images/button_red.png',
+                                height:
+                                    MediaQuery.of(context).size.height * 0.07,
+                                fit: BoxFit.fill),
+                            label: Text('Maybe later!',
+                                style: textStyle.copyWith(
+                                    color: Colors.red,
+                                    fontSize:
+                                        MediaQuery.of(context).size.height *
+                                            0.05)),
+                          ),
+                        ]
                       ),
-                      onPressed: () {
-                        gameState.reset();
-                        Navigator.of(context).pushNamedAndRemoveUntil(
-                          '/',
-                          (route) => false,
-                        );
-                      },
-                      icon: Image.asset('assets/images/button_blue.png',
-                          height: config.button_pic_h,
-                          width: config.button_pic_w,
-                          fit: BoxFit.fill),
-                      label: Text(
-                        'Yes!',
-                        style: textStyle.copyWith(
-                            color: Colors.white, fontWeight: FontWeight.w500),
-                      ),
-                    ),
-                    const SizedBox(height: 10),
-                    ElevatedButton.icon(
-                      style: ButtonStyle(
-                        padding:
-                            MaterialStateProperty.all(const EdgeInsets.all(20)),
-                        overlayColor: MaterialStateProperty.all(
-                          Colors.black.withOpacity(0.2),
-                        ),
-                        side: MaterialStateProperty.all(
-                          const BorderSide(color: Colors.white),
-                        ),
-                        backgroundColor:
-                            MaterialStateProperty.all(Colors.transparent),
-                        shadowColor:
-                            MaterialStateProperty.all(Colors.transparent),
-                      ),
-                      onPressed: () {
-                        gameState.reset();
-                        Navigator.of(context).pushNamedAndRemoveUntil(
-                          '/',
-                          (route) => false,
-                        );
-                      },
-                      icon: Image.asset('assets/images/button_red.png',
-                          height: config.button_pic_h,
-                          width: config.button_pic_w,
-                          fit: BoxFit.fill),
-                      label: Text(
-                        'Maybe later!',
-                        style: textStyle.copyWith(
-                          color: Colors.red,
-                        ),
-                      ),
-                    )
                   ],
                 ),
               ),

--- a/lib/widgets/interface_game.dart
+++ b/lib/widgets/interface_game.dart
@@ -32,7 +32,7 @@ class _InterfaceGameState extends State<InterfaceGame> {
     const textStyle = TextStyle(
       color: Colors.black,
       fontWeight: FontWeight.bold,
-      fontSize: 18,
+      fontSize: 28,
     );
     return Material(
       type: MaterialType.transparency,
@@ -50,13 +50,13 @@ class _InterfaceGameState extends State<InterfaceGame> {
               _state.score.toString(),
               style: textStyle,
             ),
-            const SizedBox(height: 10),
+            SizedBox(height: MediaQuery.of(context).size.height * 0.01),
             Wrap(
-              spacing: 10,
+              spacing: MediaQuery.of(context).size.width * 0.02,
               children: List.generate(_state.lifes, (i) {
                 return SizedBox(
-                  width: sizeIcon,
-                  height: sizeIcon,
+                  width: MediaQuery.of(context).size.height * 0.03,
+                  height: MediaQuery.of(context).size.height * 0.03,
                   child: UtilSpriteSheet.dotPower.asWidget(),
                 );
               }),


### PR DESCRIPTION
- let camera be focused on the game map, not the player, so we have a properly centered view
- zoom out on win or lose, so people won't be distracted with the game in the background
- remove most of the scaling configs
- scale items by MediaQuery info
- put buttons into a row for the dialogs
- fix offset of menu animation, so items don't "pop" in
- scale fonts accordlingly